### PR TITLE
dev-git-blanc-be-gone tool

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,28 @@ Example of use:
     $ blanc-wipeenv
 
 
+dev-git-blanc-be-gone
+---------------------
+
+A handy tool to change the URL of the 'origin' remote from:
+
+* git@github.com:blancltd/something.git
+
+To:
+
+* git@github.com:developersociety/something.git
+
+Will only change anything if it detects the current project's origin URL is for 'blancltd', so is
+safe to use willy-nilly.
+
+Example of use:
+~~~~~~~~~~~~~~~
+
+::
+
+    $ dev-git-blanc-be-gone
+
+
 Git Hooks
 =========
 

--- a/bin/dev-git-blanc-be-gone
+++ b/bin/dev-git-blanc-be-gone
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if git remote get-url origin | grep "git@github.com:blancltd/"; then
+    echo
+    echo "Aha!"
+    echo
+    new="$(git remote get-url origin | sed 's/:blancltd\//:developersociety\//')"
+    git remote set-url origin "$new"
+    echo "Have changed origin's URL. It's now:"
+    echo -e "\t$(git remote get-url origin)"
+    echo
+else
+    echo
+    echo "Doesn't look like this is a blancltd repo. There's nothing for me to do :("
+    echo
+fi


### PR DESCRIPTION
Tool to change the origin url of the current project from blancltd to developersociety.

Fixes #38