### PR TITLE
Exclude main branch from pruning

### DIFF
--- a/bin/dev-clean-branches
+++ b/bin/dev-clean-branches
@@ -9,7 +9,7 @@ if [[ ! -f .git/refs/remotes/origin/HEAD ]]; then
 fi
 
 DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed -e "s|^refs/remotes/origin/||")
-BRANCHES=$(git branch --merged "$DEFAULT_BRANCH" --format "%(refname:short)" | grep -v -e "^master$" -e "^dev$" -e "^${DEFAULT_BRANCH}$")
+BRANCHES=$(git branch --merged "$DEFAULT_BRANCH" --format "%(refname:short)" | grep -v -e "^main$" -e "^master$" -e "^dev$" -e "^${DEFAULT_BRANCH}$")
 
 if [[ -n $BRANCHES ]]; then
     echo "Will remove the following branches:"


### PR DESCRIPTION
main is now the default branch, however we'll leave master in for legacy projects

To test:

`dev-clean-branches` on a project with a main branch where dev is the default and main is behind without any missing commits.

(or trust me on it!)