### PR TITLE
Use VIRTUALENVWRAPPER_VIRTUALENV to create a virtualenv

### DIFF
--- a/bin/dev-clone
+++ b/bin/dev-clone
@@ -37,7 +37,10 @@ set +u
 if grep --fixed-strings --silent "basepython" tox.ini;
 then
     PYTHON_VERSION=$(sed -e 's/basepython[[:space:]]=[[:space:]]//' -e 'tx' -e 'd' -e ':x' tox.ini | head -n 1)
-    mkproject --force --python="$PYTHON_VERSION" "$REPO_NAME"
+    PYTHON_VERSION_NUMBER=${PYTHON_VERSION/python/}
+    LATEST_PYTHON=$(pyenv latest "$PYTHON_VERSION_NUMBER")
+    VIRTUALENV_EXE=$(PYENV_VERSION=$LATEST_PYTHON pyenv which virtualenv)
+    VIRTUALENVWRAPPER_VIRTUALENV=$VIRTUALENV_EXE mkproject --force --python="$PYTHON_VERSION" "$REPO_NAME"
 else
     mkproject --force "$REPO_NAME"
 fi


### PR DESCRIPTION
To test:

Install virtualenv into all of your Python versions:

```
python2.7 -m pip install virtualenv
python3.5 -m pip install virtualenv
python3.6 -m pip install virtualenv
python3.7 -m pip install virtualenv
python3.8 -m pip install virtualenv
python3.9 -m pip install virtualenv
python3.10 -m pip install virtualenv
python3.11 -m pip install virtualenv
```

Then `dev-clone` a project which is Python 3.6 and has a tox.ini (eg. `dev-clone bhi`).